### PR TITLE
feat(publishers): add IALA, IHO, Adobe flavors + NIST/OIML doc types

### DIFF
--- a/.vitepress/data/component-data.ts
+++ b/.vitepress/data/component-data.ts
@@ -46,7 +46,7 @@ const data: Record<string, CM> = {
   },
   nist: {
     Publisher: { dataType: 'enum', values: ['NIST', 'NBS'], format: 'NBS for pre-1988 documents.', example: 'NIST' },
-    'Document Type': { dataType: 'enum', values: ['SP', 'FIPS', 'IR', 'TN', 'HB', 'CIRC', 'MONO', 'RPT', 'LCIRC', 'GCR', 'CRPL', 'NSRDS', 'NCSTAR', 'OWMWP', 'CS', 'MP', 'CSM', 'CSE'], example: 'SP' },
+    'Document Type': { dataType: 'enum', values: ['SP', 'FIPS', 'IR', 'TN', 'HB', 'CIRC', 'MONO', 'RPT', 'LCIRC', 'GCR', 'CRPL', 'NSRDS', 'NCSTAR', 'OWMWP', 'CS', 'MP', 'CSM', 'CSE', 'RB', 'CHIPS', 'NWIRP'], example: 'SP' },
     Number: { dataType: 'string', format: '1–6 digits. May include dash-separated sub-numbers (e.g., 800-53).', example: '800-53' },
     Part: { dataType: 'string', format: 'Optional. Appended after number with dash.', example: '3' },
     Revision: { dataType: 'string', format: 'Optional. Prefixed with "Rev."', example: 'Rev. 5' },
@@ -173,6 +173,30 @@ const data: Record<string, CM> = {
     Type: { dataType: 'enum', values: ['J (Ground Vehicle)', 'AS (Aerospace Standard)', 'ARP (Aerospace Recommended Practice)', 'AIR (Aerospace Information Report)', 'AMS (Aerospace Material Specification)'], example: 'J' },
     Number: { dataType: 'string', format: 'Alphanumeric. May include letter suffix for version.', example: 'J3016' },
     Year: { dataType: 'year', format: '4-digit year, preceded by hyphen.', example: '2021' },
+  },
+  iala: {
+    Publisher: { dataType: 'enum', values: ['IALA'], example: 'IALA' },
+    'Type Letter': { dataType: 'enum', values: ['S (Standard)', 'R (Recommendation)', 'G (Guideline)', 'M (Manual)', 'C (Model Course)', 'A (Advice)', 'L (Letter)', 'GA (General Assembly)', 'X (Report)', 'P (Resolution)'], example: 'R' },
+    Number: { dataType: 'string', format: '4-digit zero-padded for S/R/G/M/C; dotted series.index for GA; dotted series.subseries.item for L', example: '0103' },
+    'Sub-part': { dataType: 'integer', format: 'Optional. Hyphenated suffix on the number.', example: '-1' },
+    Edition: { dataType: 'string', format: '"Ed X.Y" (cover form) or ":edX.Y" (compact listing form).', example: 'Ed 3.0' },
+    Language: { dataType: 'enum', values: ['E (English)', 'F (French)', 'S (Spanish)', 'C (Chinese)', 'A (Arabic)', 'R (Russian)'], format: 'Optional. Single uppercase letter in parentheses.', example: 'F' },
+  },
+  iho: {
+    Publisher: { dataType: 'enum', values: ['IHO'], example: 'IHO' },
+    'Type Letter': { dataType: 'enum', values: ['S (Standard/Specification)', 'P (Publication)', 'M (Miscellaneous)', 'B (Bibliographic)', 'C (Circular Letter)'], example: 'S' },
+    Number: { dataType: 'string', format: 'Hyphenated after type letter. May include slash-year (P-1/21) or sub-part (P-6-3).', example: '44' },
+    Appendix: { dataType: 'string', format: '"Ap." prefix, single letter.', example: 'Ap. A' },
+    Part: { dataType: 'string', format: '"Part" keyword. Alphanumeric allowed (e.g. 4a).', example: 'Part 4a' },
+    Annex: { dataType: 'string', format: '"Annex" keyword.', example: 'Annex A' },
+    Supplement: { dataType: 'string', format: '"Suppl" keyword.', example: 'Suppl 1' },
+    Version: { dataType: 'string', format: 'Three-part dotted version (X.Y.Z).', example: '5.0.0' },
+  },
+  adobe: {
+    Publisher: { dataType: 'enum', values: ['Adobe'], example: 'Adobe' },
+    Slug: { dataType: 'string', format: 'Kebab-case slug for named publications (adobe-glyph-list, adobe-japan1).', example: 'adobe-japan1' },
+    Number: { dataType: 'integer', format: '4-digit Technical Note number, typically 5xxx series.', example: '5014' },
+    Version: { dataType: 'integer', format: 'Collection version (Adobe-Japan1-7 → version 7).', example: '7' },
   },
 }
 

--- a/.vitepress/data/publishers.ts
+++ b/.vitepress/data/publishers.ts
@@ -745,6 +745,219 @@ export const publishers: Publisher[] = [
       { type: 'Supplement', description: 'Additional content', syntax: 'ITU-[Sector] [Series].[Number] Suppl [N]', example: 'ITU-T G.992.1 Suppl 1' },
     ],
   },
+  {
+    flavor: 'iala',
+    logo: '/logos/iala-logo.svg',
+    name: 'IALA',
+    fullName: 'International Association of Marine Aids to Navigation and Lighthouse Authorities',
+    category: 'international',
+    description: "IALA is an international technical association that gathers marine aids to navigation authorities, industry manufacturers and consultants to harmonize and improve marine aids to navigation worldwide. IALA Recommendations and Standards guide lighthouse authorities, vessel traffic services, and e-Navigation implementations across more than 90 member countries.",
+    website: 'https://www.iala-aism.org',
+    syntaxNotes: "IALA identifiers use a single-letter type prefix followed by a 4-digit zero-padded number: IALA {S|R|G|M|C|A|L|GA|X|P}[Number][ Ed [Edition]][ ([LangLetter])]. General Assembly resolutions use a dotted series.index form (GA01.01).",
+    urnPattern: 'urn:iala:[type]:[number]:[edition]:[language]',
+    relatedFlavors: ['iso', 'iho', 'iec'],
+    docTypes: [
+      {
+        key: 'standard',
+        title: 'Standard',
+        abbr: ['S'],
+        description: 'IALA Standards (S series) define normative requirements for marine aids to navigation systems, including the IALA Maritime Buoyage System and e-Navigation components.',
+        examples: [
+          { input: 'IALA S1010' },
+          { input: 'IALA S1020 Ed 2.0' },
+          { input: 'IALA S1070 Ed 2.0' },
+        ],
+      },
+      {
+        key: 'recommendation',
+        title: 'Recommendation',
+        abbr: ['R'],
+        description: 'IALA Recommendations (R series) are the principal deliverable type, recommending practices and systems to be adopted by member authorities.',
+        examples: [
+          { input: 'IALA R0103 Ed 3.1' },
+          { input: 'IALA R0126 Ed 2.0' },
+          { input: 'IALA R1024 Ed 1.0' },
+        ],
+      },
+      {
+        key: 'guideline',
+        title: 'Guideline',
+        abbr: ['G'],
+        description: 'IALA Guidelines (G series) provide practical guidance for the implementation and operation of aids to navigation systems.',
+        examples: [
+          { input: 'IALA G1015 Ed 2.2' },
+          { input: 'IALA G1045 Ed 1' },
+          { input: 'IALA G1078 Ed 2.1' },
+        ],
+      },
+      {
+        key: 'manual',
+        title: 'Manual',
+        abbr: ['M'],
+        description: 'IALA Manuals (M series). Most current manuals (NAVGUIDE, VTS Manual) carry no number; the M prefix is reserved for future numbered manuals.',
+        examples: [
+          { input: 'IALA M0001' },
+        ],
+      },
+      {
+        key: 'model_course',
+        title: 'Model Course',
+        abbr: ['C'],
+        description: 'IALA Model Courses (C series) define training programmes for aids to navigation personnel and VTS operators.',
+        examples: [
+          { input: 'IALA C0103-1 Ed 3.0' },
+          { input: 'IALA C2001-1 Ed 1.0' },
+        ],
+      },
+      {
+        key: 'advice',
+        title: 'Advice',
+        abbr: ['A'],
+        description: 'IALA Advices (A series) are brief advisory notes issued by IALA committees. Numbering is dashed (A12-01, A13-04) and they carry no edition.',
+        examples: [
+          { input: 'IALA A12-01' },
+          { input: 'IALA A13-04' },
+        ],
+      },
+      {
+        key: 'general_assembly',
+        title: 'General Assembly Resolution',
+        abbr: ['GA'],
+        description: 'Resolutions of the IALA General Assembly, numbered with a dotted series.index form (volume = series, sequence = index).',
+        examples: [
+          { input: 'IALA GA01.01' },
+          { input: 'IALA GA01.13' },
+        ],
+      },
+      {
+        key: 'letter',
+        title: 'Letter',
+        abbr: ['L'],
+        description: 'IALA Letters (L series) use a multi-dotted series.sub-series.item form, with an optional sub-part suffix.',
+        examples: [
+          { input: 'IALA L2.1.11' },
+          { input: 'IALA L2.7.1-2' },
+        ],
+      },
+      {
+        key: 'annex',
+        title: 'Annex',
+        abbr: ['Annex'],
+        description: 'Annex to an IALA base publication (typically a Guideline). The "Annex"/"ANNEX" marker case is preserved verbatim, with an optional single-letter suffix (A–D).',
+        examples: [
+          { input: 'IALA G1045 Annex Ed 1' },
+          { input: 'IALA G1128 ANNEX A Ed 1.6' },
+        ],
+      },
+      {
+        key: 'report',
+        title: 'Report',
+        abbr: ['X'],
+        description: 'IALA Reports & Proceedings (X series, reserved). Current reports carry no code; X is reserved for future numbered reports.',
+        examples: [],
+      },
+      {
+        key: 'resolution',
+        title: 'Resolution',
+        abbr: ['P'],
+        description: 'IALA Council Resolutions and publications (P series, reserved). Current resolutions carry no code; P is reserved for future numbered resolutions.',
+        examples: [],
+      },
+    ],
+    components: [
+      { name: 'Publisher', description: 'IALA — optional on input, always emitted on output' },
+      { name: 'Type Letter', description: 'Single-letter type code (S, R, G, M, C, A, L, GA, X, P)', attribute: 'type_letter' },
+      { name: 'Number', description: '4-digit zero-padded number; GA series uses dotted series.index', attribute: 'number' },
+      { name: 'Sub-part', description: 'Optional hyphenated sub-part suffix', attribute: 'subpart' },
+      { name: 'Edition', description: 'Prefixed with "Ed" (cover form) or ":ed" (compact listing form)', attribute: 'edition' },
+      { name: 'Language', description: 'Single uppercase letter in parentheses: E, F, S, C, A, R', attribute: 'language' },
+    ],
+    algebra: [
+      { type: 'Edition', description: 'Cover-page vs listing-page edition forms', syntax: 'IALA [Type][Number] Ed [X.Y] | IALA [Type][Number]:ed[X.Y]', example: 'IALA R1016 Ed 2.0' },
+      { type: 'Sub-part', description: 'Sub-part within a numbered publication', syntax: 'IALA [Type][Number]-[SubPart] Ed [X.Y]', example: 'IALA C0103-1 Ed 3.0' },
+      { type: 'Annex', description: 'Wraps a base publication with an annex marker', syntax: 'IALA [Type][Number] Annex [A-D] Ed [X.Y]', example: 'IALA G1128 ANNEX A Ed 1.6' },
+      { type: 'Language', description: 'Translation suffix as a parenthesised letter', syntax: 'IALA [Type][Number] Ed [X.Y] ([Lang])', example: 'IALA R1016 Ed 2.0 (F)' },
+    ],
+  },
+  {
+    flavor: 'iho',
+    logo: '/logos/iho-logo.svg',
+    name: 'IHO',
+    fullName: 'International Hydrographic Organization',
+    category: 'international',
+    description: "The IHO is an intergovernmental organization that coordinates the setting of international hydrographic and nautical charting standards. Its Standards and Specifications (S-series) underpin Electronic Navigational Charts (ENCs) and the developing S-100 Universal Hydrographic Data Model used by mariners and maritime software worldwide.",
+    website: 'https://iho.int',
+    syntaxNotes: "IHO identifiers use a single-letter series prefix followed by a hyphenated number: IHO {S|P|M|B|C}-[Number][ Ap. [Appendix]][ Part [Part]][ Annex [Annex]][ Suppl [Supplement]] [Version].",
+    urnPattern: 'urn:iho:[type]:[number]:[version]',
+    relatedFlavors: ['iso', 'iala', 'iec'],
+    docTypes: [
+      {
+        key: 'standard',
+        title: 'Standards and Specifications',
+        abbr: ['S'],
+        description: 'IHO Standards and Specifications (S series), including the S-100 Universal Hydrographic Data Model and the S-57/S-101 ENC transfer standards.',
+        examples: [
+          { input: 'IHO S-44 5.0.0' },
+          { input: 'IHO S-100 Part 4a 1.0.0' },
+          { input: 'IHO S-65 Ap. A 1.0.0' },
+        ],
+      },
+      {
+        key: 'publication',
+        title: 'Publication',
+        abbr: ['P'],
+        description: 'IHO Publications (P series) — reference works such as Charts and Publications Regulations. Numbers may carry a sub-year (P-1/21) or sub-part (P-6-3).',
+        examples: [
+          { input: 'IHO P-1 1.0.0' },
+          { input: 'IHO P-1/21 1.0.0' },
+          { input: 'IHO P-6-3 1.0.0' },
+        ],
+      },
+      {
+        key: 'miscellaneous',
+        title: 'Miscellaneous Publication',
+        abbr: ['M'],
+        description: 'IHO Miscellaneous Publications (M series) — manuals, guides, and reference documents that do not fit the S/P categories.',
+        examples: [
+          { input: 'IHO M-3 2.0.0' },
+        ],
+      },
+      {
+        key: 'bibliographic',
+        title: 'Bibliographic Publication',
+        abbr: ['B'],
+        description: 'IHO Bibliographic Publications (B series) — bibliographies and reference catalogues.',
+        examples: [
+          { input: 'IHO B-4 2.19.0' },
+        ],
+      },
+      {
+        key: 'circular_letter',
+        title: 'Circular Letter',
+        abbr: ['C'],
+        description: 'IHO Circular Letters (C series) — official correspondence from the IHO Secretariat to Member States.',
+        examples: [
+          { input: 'IHO C-13 1.0.0' },
+        ],
+      },
+    ],
+    components: [
+      { name: 'Publisher', description: 'IHO — optional on input, always emitted on output' },
+      { name: 'Type Letter', description: 'Single-letter series code (S, P, M, B, C)', attribute: 'type_letter' },
+      { name: 'Number', description: 'Document number, may include sub-part or slash-year', attribute: 'number' },
+      { name: 'Appendix', description: 'Appendix marker: "Ap." prefix', attribute: 'appendix' },
+      { name: 'Part', description: 'Part marker: "Part" keyword', attribute: 'part' },
+      { name: 'Annex', description: 'Annex marker: "Annex" keyword', attribute: 'annex' },
+      { name: 'Supplement', description: 'Supplement marker: "Suppl" keyword', attribute: 'supplement' },
+      { name: 'Version', description: 'Three-part dotted version (X.Y.Z)', attribute: 'version' },
+    ],
+    algebra: [
+      { type: 'Part', description: 'Subdivision of a standard', syntax: 'IHO [Type]-[Number] Part [Part] [Version]', example: 'IHO S-100 Part 4a 1.0.0' },
+      { type: 'Appendix', description: 'Appendix within a publication', syntax: 'IHO [Type]-[Number] Ap. [Letter] [Version]', example: 'IHO S-65 Ap. A 1.0.0' },
+      { type: 'Slash Year', description: 'Annual revision indicator within a series', syntax: 'IHO [Type]-[Number]/[Year] [Version]', example: 'IHO P-1/21 1.0.0' },
+      { type: 'Sub-part', description: 'Compound number with sub-part', syntax: 'IHO [Type]-[Number]-[SubPart] [Version]', example: 'IHO P-6-3 1.0.0' },
+    ],
+  },
   // ─── REGIONAL ──────────────────────────────────────────────────
   {
     flavor: 'cen-cenelec',
@@ -1160,6 +1373,35 @@ export const publishers: Publisher[] = [
         description: 'Emergency Commercial Standards.',
         examples: [
           { input: 'NBS CSE 1' },
+        ]
+      },
+      {
+        key: 'research_brief',
+        title: 'Research Brief',
+        abbr: ['RB'],
+        description: "NIST Research Briefs — short-form research summaries from NIST laboratories. Revisions are appended as a lowercase 'r' suffix (e.g. 6r1).",
+        examples: [
+          { input: 'NIST RB 6' },
+          { input: 'NIST RB 4r1' },
+        ]
+      },
+      {
+        key: 'chips_act_rd',
+        title: 'CHIPS Act R&D',
+        abbr: ['CHIPS'],
+        description: "Publications under the NIST CHIPS Research and Development program (Creating Helpful Incentives to Produce Semiconductors). Numbers are compound, hyphenated (e.g. 1400-3).",
+        examples: [
+          { input: 'NIST CHIPS 1400-3' },
+          { input: 'NIST CHIPS 1100-1' },
+        ]
+      },
+      {
+        key: 'nwirp',
+        title: 'NWIRP',
+        abbr: ['NWIRP'],
+        description: 'Low-volume NIST series present in the MODS publication dump.',
+        examples: [
+          { input: 'NIST NWIRP 1' },
         ]
       },
     ],
@@ -2073,6 +2315,19 @@ export const publishers: Publisher[] = [
         ]
       },
       {
+        key: 'bulletin',
+        title: 'Bulletin',
+        abbr: ['Bulletin'],
+        description: 'The OIML Bulletin is the periodical of the International Organization of Legal Metrology, published since 1960 (Volume I). It has a four-tier hierarchy: periodical (OIML Bulletin), volume/year (OIML Bulletin 1960), issue (OIML Bulletin 1960-03), and article (OIML Bulletin 1960-03-01). Each article also has a citation form combining roman volume, parenthesised issue, and 8-digit article id (OIML Bulletin LXVII(2) 20260211).',
+        examples: [
+          { input: 'OIML Bulletin' },
+          { input: 'OIML Bulletin 1960' },
+          { input: 'OIML Bulletin 1960-03' },
+          { input: 'OIML Bulletin 1960-03-01' },
+          { input: 'OIML Bulletin LXVII(2) 20260211' },
+        ]
+      },
+      {
         key: 'amendment',
         title: 'Amendment',
         abbr: ['Amd'],
@@ -2104,6 +2359,9 @@ export const publishers: Publisher[] = [
       { type: 'Amendment', description: 'Modifies an OIML publication', syntax: 'Amendment ([Year]) to OIML [Type] [Number]:[Year] (E)', example: 'Amendment (2009) to OIML R 138:2007 (E)' },
       { type: 'Annex', description: 'Annex to a publication', syntax: 'OIML [Type] [Number] Annex [Letter]', example: 'OIML R 49-1 Annex A' },
       { type: 'Part', description: 'Multi-part publication', syntax: 'OIML [Type] [Number]-[Part]:[Year]', example: 'OIML R 76-1:2006' },
+      { type: 'Bulletin Issue', description: 'Issue of the OIML Bulletin periodical', syntax: 'OIML Bulletin [Year]-[Issue]', example: 'OIML Bulletin 1960-03' },
+      { type: 'Bulletin Article', description: 'Structured article reference within an issue', syntax: 'OIML Bulletin [Year]-[Issue]-[Sequence]', example: 'OIML Bulletin 1960-03-01' },
+      { type: 'Bulletin Citation', description: 'Citation form combining roman volume and article id', syntax: 'OIML Bulletin [RomanVolume]([Issue]) [ArticleID]', example: 'OIML Bulletin LXVII(2) 20260211' },
     ],
   },
   {
@@ -2455,6 +2713,54 @@ export const publishers: Publisher[] = [
       { name: 'Date', description: 'Publication date', attribute: 'date' },
     ],
     algebra: [],
+  },
+  {
+    flavor: 'adobe',
+    logo: '/logos/adobe-logo.svg',
+    name: 'Adobe',
+    fullName: 'Adobe Inc.',
+    category: 'industry',
+    description: "Adobe publishes foundational technical specifications for digital typography, font formats, and document interchange — including the Adobe Glyph List, PostScript Language Reference, CIDFont specifications, and the Adobe-Japan/Korea/CJK character collections. These underpin modern text rendering engines and CJK font workflows.",
+    website: 'https://www.adobe.com',
+    syntaxNotes: 'Adobe identifiers use two shapes: slug-keyed publications (Adobe Glyph List, Adobe-Japan1-7) and numbered Technical Notes (Adobe Technical Note #5014, ATN5014).',
+    relatedFlavors: ['iso'],
+    docTypes: [
+      {
+        key: 'publication',
+        title: 'Publication',
+        abbr: [''],
+        description: 'Adobe named publications identified by a kebab-case slug, optionally versioned. Includes character collections (Adobe-Japan1), the Adobe Glyph List, and the PostScript Language Reference.',
+        examples: [
+          { input: 'Adobe Glyph List' },
+          { input: 'Adobe-Japan1-7' },
+          { input: 'Adobe-Korea1-2' },
+          { input: 'Adobe-CNS1-0' },
+          { input: 'Adobe-GB1-5' },
+        ],
+      },
+      {
+        key: 'tech_note',
+        title: 'Technical Note',
+        abbr: ['ATN'],
+        description: 'Adobe Technical Notes are numbered 4-digit (typically 5xxx series) technical specifications such as AFM, CIDFont, and SFNT-Mask specifications. They have a formal citation form (Adobe Technical Note #5014) and a short alias (ATN5014) used in document anchors.',
+        examples: [
+          { input: 'Adobe Technical Note #5014' },
+          { input: 'ATN5014' },
+          { input: 'Adobe Technical Note #5902' },
+        ],
+      },
+    ],
+    components: [
+      { name: 'Publisher', description: 'Adobe' },
+      { name: 'Slug', description: 'Kebab-case slug for publications (adobe-glyph-list, adobe-japan1)', attribute: 'slug' },
+      { name: 'Number', description: '4-digit Technical Note number (5xxx series)', attribute: 'number' },
+      { name: 'Version', description: 'Collection version (Adobe-Japan1-7 → version 7)', attribute: 'version' },
+    ],
+    algebra: [
+      { type: 'Short Alias', description: 'Anchor-id form used in cross-references', syntax: 'ATN[Number]', example: 'ATN5014' },
+      { type: 'Citation Form', description: 'Formal citation form', syntax: 'Adobe Technical Note #[Number]', example: 'Adobe Technical Note #5014' },
+      { type: 'Collection Version', description: 'Character collection with version', syntax: 'Adobe-[Collection]-[Version]', example: 'Adobe-Japan1-7' },
+    ],
   },
 ]
 

--- a/.vitepress/data/publishers.ts
+++ b/.vitepress/data/publishers.ts
@@ -752,7 +752,7 @@ export const publishers: Publisher[] = [
     fullName: 'International Association of Marine Aids to Navigation and Lighthouse Authorities',
     category: 'international',
     description: "IALA is an international technical association that gathers marine aids to navigation authorities, industry manufacturers and consultants to harmonize and improve marine aids to navigation worldwide. IALA Recommendations and Standards guide lighthouse authorities, vessel traffic services, and e-Navigation implementations across more than 90 member countries.",
-    website: 'https://www.iala-aism.org',
+    website: 'https://www.iala.int',
     syntaxNotes: "IALA identifiers use a single-letter type prefix followed by a 4-digit zero-padded number: IALA {S|R|G|M|C|A|L|GA|X|P}[Number][ Ed [Edition]][ ([LangLetter])]. General Assembly resolutions use a dotted series.index form (GA01.01).",
     urnPattern: 'urn:iala:[type]:[number]:[edition]:[language]',
     relatedFlavors: ['iso', 'iho', 'iec'],

--- a/public/logos/adobe-logo.svg
+++ b/public/logos/adobe-logo.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 80">
+  <rect width="240" height="80" rx="6" fill="#fa0f00"/>
+  <g transform="translate(20 16)">
+    <path d="M20 0 L0 48 L12 48 L20 28 L28 48 L40 48 Z" fill="#ffffff"/>
+  </g>
+  <text x="78" y="50" font-family="'Helvetica Neue', Arial, sans-serif" font-size="26" font-weight="700" letter-spacing="1" fill="#ffffff">Adobe</text>
+</svg>

--- a/public/logos/iala-logo.svg
+++ b/public/logos/iala-logo.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 80">
+  <rect width="240" height="80" rx="6" fill="#0a2540"/>
+  <g transform="translate(20 18)">
+    <path d="M14 4 L7 44 L21 44 Z" fill="#ffffff"/>
+    <rect x="11" y="44" width="6" height="4" fill="#ffffff"/>
+    <rect x="9" y="48" width="10" height="2" fill="#ffffff"/>
+    <path d="M0 22 Q5 17 12 17 L12 21 Q8 21 4 25 Z" fill="#5fc9f8"/>
+    <path d="M28 22 Q23 17 16 17 L16 21 Q20 21 24 25 Z" fill="#5fc9f8"/>
+  </g>
+  <text x="80" y="50" font-family="'Helvetica Neue', Arial, sans-serif" font-size="28" font-weight="700" letter-spacing="3" fill="#ffffff">IALA</text>
+</svg>

--- a/public/logos/iho-logo.svg
+++ b/public/logos/iho-logo.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 80">
+  <rect width="240" height="80" rx="6" fill="#0073cf"/>
+  <g transform="translate(18 36)">
+    <path d="M0 4 Q6 -4 12 4 T24 4 T36 4" stroke="#ffffff" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M0 12 Q6 4 12 12 T24 12 T36 12" stroke="#ffffff" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.7"/>
+    <path d="M0 20 Q6 12 12 20 T24 20 T36 20" stroke="#ffffff" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.45"/>
+  </g>
+  <text x="80" y="50" font-family="'Helvetica Neue', Arial, sans-serif" font-size="28" font-weight="700" letter-spacing="3" fill="#ffffff">IHO</text>
+</svg>


### PR DESCRIPTION
## Summary

Syncs the site with the flavors implemented in pubid core (`metanorma/pubid` main). Total publisher count goes **23 → 26**, which makes the existing "26+ publishers" copy on `about.md` and `adopt.md` accurate rather than aspirational.

### New publisher schemas

- **IALA** (International Association of Marine Aids to Navigation and Lighthouse Authorities) — international category, 11 doc types: Standard (S), Recommendation (R), Guideline (G), Manual (M), Model Course (C), Advice (A), General Assembly Resolution (GA), Letter (L), Annex, Report (X), Resolution (P)
- **IHO** (International Hydrographic Organization) — international category, 5 doc types: Standards & Specifications (S), Publication (P), Miscellaneous (M), Bibliographic (B), Circular Letter (C)
- **Adobe** — industry category, 2 doc types: Publication (slug-keyed, e.g. Adobe-Japan1-7) and Technical Note (ATN, e.g. ATN5014)

### New doc types on existing flavors

- **NIST**: Research Brief (RB), CHIPS Act R&D (CHIPS), NWIRP — recently added in pubid commit `f22d93f5`
- **OIML**: Bulletin (periodical/volume/issue/article hierarchy with structured `OIML Bulletin 1960-03-01` and citation `OIML Bulletin LXVII(2) 20260211` forms) — pubid commit `47a9a0aa`

### Other changes

- `component-data.ts`: added typed metadata for IALA, IHO, Adobe (so the Components grid shows data types, formats, and examples consistent with other publishers). Added RB/CHIPS/NWIRP to the NIST Document Type enum.
- `public/logos/`: simple brand-color SVG logos (IALA navy + lighthouse mark, IHO blue + wave mark, Adobe red + A mark) so the publisher grid is visually consistent.

## Test plan

- [x] `npm run build` — clean build, no warnings
- [x] All 26 publisher pages generate (verified in `.vitepress/dist/publishers/`)
- [x] `npm run dev` — every new route (`/publishers/iala/`, `/publishers/iho/`, `/publishers/adobe/`) returns 200
- [x] PublisherGrid renders the 3 new cards with logos visible
- [x] Hero subtitle auto-updates: "Parse, render, and exchange standards identifiers across **26+ publishers**"
- [x] IALA doc type count shows 11, IHO shows 5, Adobe shows 2
- [x] OIML page shows the new Bulletin doc type with all 5 example forms
- [x] NIST page shows RB, CHIPS, NWIRP doc types with examples